### PR TITLE
Add basic Tuple implementations

### DIFF
--- a/acorn/container/BUILD
+++ b/acorn/container/BUILD
@@ -6,3 +6,10 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [],
 )
+
+cc_library(
+    name = "tuple",
+    srcs = ["tuple.h"],
+    visibility = ["//visibility:public"],
+    deps = ["//acorn/traits"],
+)

--- a/acorn/container/BUILD
+++ b/acorn/container/BUILD
@@ -11,5 +11,8 @@ cc_library(
     name = "tuple",
     srcs = ["tuple.h"] + glob(["tuple/*.h"]),
     visibility = ["//visibility:public"],
-    deps = ["//acorn/traits"],
+    deps = [
+        "//acorn/traits",
+        "@com_google_absl//absl/utility",
+    ],
 )

--- a/acorn/container/BUILD
+++ b/acorn/container/BUILD
@@ -9,7 +9,7 @@ cc_library(
 
 cc_library(
     name = "tuple",
-    srcs = ["tuple.h"],
+    srcs = ["tuple.h"] + glob(["tuple/*.h"]),
     visibility = ["//visibility:public"],
     deps = ["//acorn/traits"],
 )

--- a/acorn/container/tuple.h
+++ b/acorn/container/tuple.h
@@ -31,6 +31,7 @@
 #ifndef ACORN_CONTAINER_TUPLE_H_
 #define ACORN_CONTAINER_TUPLE_H_
 
+#include "acorn/container/tuple/flat_inherited_tuple.h"
 #include "acorn/container/tuple/member_tuple.h"
 #include "acorn/container/tuple/nested_inherited_tuple.h"
 
@@ -45,23 +46,35 @@ namespace acorn {
 #ifdef ACORN_STANDARD_LAYOUT_TUPLE
 #define INLINE_MEMBER inline
 #define INLINE_NESTED_INHERITED
-#else
+#define INLINE_FLAT_INHERITED
+#elif ACORN_NESTED_LAYOUT_TUPLE
 #define INLINE_MEMBER
 #define INLINE_NESTED_INHERITED inline
+#define INLINE_FLAT_INHERITED
+#else
+#define INLINE_MEMBER
+#define INLINE_NESTED_INHERITED
+#define INLINE_FLAT_INHERITED inline
 #endif
 
 INLINE_MEMBER namespace member {
-template <typename... Args>
-using Tuple = MemberTuple<Args...>;
+  template <typename... Args>
+  using Tuple = MemberTuple<Args...>;
 }
 
 INLINE_NESTED_INHERITED namespace nested_inherited {
-template <typename... Args>
-using Tuple = NestedInheritedTuple<Args...>;
+  template <typename... Args>
+  using Tuple = NestedInheritedTuple<Args...>;
+}
+
+INLINE_FLAT_INHERITED namespace flat_inherited {
+  template <typename... Args>
+  using Tuple = FlatInheritedTuple<Args...>;
 }
 
 #undef INLINE_MEMBER
 #undef INLINE_NESTED_INHERITED
+#undef INLINE_FLAT_INHERITED
 
 }  // namespace acorn
 

--- a/acorn/container/tuple.h
+++ b/acorn/container/tuple.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef ACORN_CONTAINER_TUPLE_H_
+#define ACORN_CONTAINER_TUPLE_H_
+
+#include "acorn/traits/remove_const_ref.h"
+#include "acorn/traits/with_ref_matching.h"
+
+#include <cstddef>
+#include <utility>
+
+namespace acorn {
+
+template <std::size_t I, template <typename...> class Tuple, typename... Args>
+struct TupleElementImpl;
+
+template <std::size_t I, template <typename...> class Tuple, typename First,
+          typename... Rest>
+struct TupleElementImpl<I, Tuple, First, Rest...>
+    : TupleElementImpl<I - 1, Tuple, Rest...> {};
+
+template <template <typename...> class Tuple, typename First, typename... Rest>
+struct TupleElementImpl<0, Tuple, First, Rest...> {
+  using type = First;
+  using TupleType = Tuple<First, Rest...>;
+};
+
+template <std::size_t I, typename Tuple>
+struct TupleElement;
+
+template <std::size_t I, template <typename...> class Tuple, typename... Args>
+struct TupleElement<I, Tuple<Args...>> : TupleElementImpl<I, Tuple, Args...> {};
+
+template <std::size_t I, typename Tuple>
+using TupleElementType = typename TupleElement<I, Tuple>::type;
+
+template <typename... Args>
+struct MemberTuple {};
+
+template <typename First, typename... Rest>
+struct MemberTuple<First, Rest...> {
+  constexpr static bool is_member_tuple = true;
+
+  template <typename FirstA, typename... RestA>
+  constexpr MemberTuple(FirstA&& arg1, RestA&&... args)
+      : arg_{std::forward<FirstA>(arg1)}, rest_{std::forward<RestA>(args)...} {}
+
+  constexpr MemberTuple() = default;
+  constexpr MemberTuple(MemberTuple&) = default;
+  constexpr MemberTuple(MemberTuple const&) = default;
+  constexpr MemberTuple(MemberTuple&&) = default;
+  MemberTuple& operator=(MemberTuple const&) = default;
+  MemberTuple& operator=(MemberTuple&&) = default;
+
+  First arg_;
+  MemberTuple<Rest...> rest_;
+};
+
+template <std::size_t I>
+struct MemberTupleGetHelper {
+  template <typename Tuple>
+  static constexpr WithRefMatching<TupleElementType<I, RemoveConstRef<Tuple>>,
+                                   Tuple>
+  get(Tuple&& tuple) noexcept {
+    return MemberTupleGetHelper<I - 1>::get(tuple.rest_);
+  }
+};
+
+template <>
+struct MemberTupleGetHelper<0> {
+  template <typename Tuple>
+  static constexpr WithRefMatching<TupleElementType<0, RemoveConstRef<Tuple>>,
+                                   Tuple>
+  get(Tuple&& tuple) noexcept {
+    return tuple.arg_;
+  }
+};
+
+template <std::size_t I, typename Tuple,
+          typename std::enable_if<Tuple::is_member_tuple, int>::type = 0>
+constexpr WithRefMatching<TupleElementType<I, RemoveConstRef<Tuple>>, Tuple>
+get(Tuple&& tuple) noexcept {
+  return MemberTupleGetHelper<I>::get(tuple);
+}
+
+template <typename... Args>
+struct InheritedTuple {};
+
+template <typename First, typename... Rest>
+struct InheritedTuple<First, Rest...> : InheritedTuple<Rest...> {
+  template <typename FirstA, typename... RestA>
+  constexpr InheritedTuple(FirstA&& arg1, RestA&&... args)
+      : InheritedTuple<Rest...>{std::forward<RestA>(args)...},
+        arg_{std::forward<FirstA>(arg1)} {}
+
+  constexpr InheritedTuple() = default;
+  constexpr InheritedTuple(InheritedTuple&) = default;
+  constexpr InheritedTuple(InheritedTuple const&) = default;
+  constexpr InheritedTuple(InheritedTuple&&) = default;
+  InheritedTuple& operator=(InheritedTuple const&) = default;
+  InheritedTuple& operator=(InheritedTuple&&) = default;
+
+  First arg_;
+};
+
+template <std::size_t I, typename Tuple,
+          typename std::enable_if<
+              std::is_base_of<InheritedTuple<>, RemoveConstRef<Tuple>>::value,
+              int>::type = 0>
+constexpr WithRefMatching<TupleElementType<I, RemoveConstRef<Tuple>>, Tuple>
+get(Tuple&& tuple) noexcept {
+  using TupleType = typename TupleElement<I, RemoveConstRef<Tuple>>::TupleType;
+  using TupleRefType = WithRefMatching<TupleType, Tuple>;
+  return static_cast<TupleRefType>(tuple).arg_;
+}
+
+}  // namespace acorn
+
+#endif  // ACORN_CONTAINER_TUPLE_H_

--- a/acorn/container/tuple/flat_inherited_tuple.h
+++ b/acorn/container/tuple/flat_inherited_tuple.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef ACORN_CONTAINER_TUPLE_FLAT_INHERITED_TUPLE_H_
+#define ACORN_CONTAINER_TUPLE_FLAT_INHERITED_TUPLE_H_
+
+#include "acorn/container/tuple/tuple_element.h"
+
+#include "acorn/traits/remove_const_ref.h"
+#include "acorn/traits/with_ref_matching.h"
+
+#include "absl/utility/utility.h"
+
+#include <cstddef>
+#include <utility>
+
+namespace acorn {
+
+template <std::size_t I, typename Arg>
+struct TupleHolder {
+  Arg value_;
+};
+
+template <typename Indices, typename... Args>
+struct FlatInheritedTupleImpl;
+
+template <std::size_t... Is, typename... Args>
+struct FlatInheritedTupleImpl<absl::index_sequence<Is...>, Args...>
+    : TupleHolder<Is, Args>... {
+  static constexpr bool is_flat_inherited_tuple = true;
+
+  template <std::size_t... IsA, typename... ArgsA>
+  constexpr FlatInheritedTupleImpl(absl::index_sequence<IsA...>,
+                                   ArgsA&&... args)
+      : TupleHolder<IsA, ArgsA>{std::forward<ArgsA>(args)}... {}
+
+  constexpr FlatInheritedTupleImpl() = default;
+};
+
+template <typename... Args>
+struct FlatInheritedTuple
+    : FlatInheritedTupleImpl<absl::make_index_sequence<sizeof...(Args)>,
+                             Args...> {
+  using IndexSequence = absl::make_index_sequence<sizeof...(Args)>;
+  using Base = FlatInheritedTupleImpl<IndexSequence, Args...>;
+
+  template <typename... ArgsA>
+  constexpr FlatInheritedTuple(ArgsA&&... args)
+      : Base{IndexSequence{}, std::forward<ArgsA>(args)...} {}
+
+  constexpr FlatInheritedTuple() = default;
+  constexpr FlatInheritedTuple(FlatInheritedTuple&) = default;
+  constexpr FlatInheritedTuple(FlatInheritedTuple const&) = default;
+  constexpr FlatInheritedTuple(FlatInheritedTuple&&) = default;
+  FlatInheritedTuple& operator=(FlatInheritedTuple const&) = default;
+  FlatInheritedTuple& operator=(FlatInheritedTuple&&) = default;
+};
+
+template <std::size_t I, typename Tuple,
+          typename std::enable_if<
+              RemoveConstRef<Tuple>::is_flat_inherited_tuple, int>::type = 0>
+constexpr WithRefMatching<TupleElementType<I, RemoveConstRef<Tuple>>, Tuple>
+get(Tuple&& tuple) noexcept {
+  using TupleType = TupleHolder<I, TupleElementType<I, RemoveConstRef<Tuple>>>;
+  using TupleRefType = WithRefMatching<TupleType, Tuple>;
+  return static_cast<TupleRefType>(tuple).value_;
+}
+
+}  // namespace acorn
+
+#endif  // ACORN_CONTAINER_TUPLE_FLAT_INHERITED_TUPLE_H_

--- a/acorn/container/tuple/tuple_element.h
+++ b/acorn/container/tuple/tuple_element.h
@@ -28,11 +28,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef ACORN_CONTAINER_TUPLE_H_
-#define ACORN_CONTAINER_TUPLE_H_
-
-#include "acorn/container/tuple/member_tuple.h"
-#include "acorn/container/tuple/nested_inherited_tuple.h"
+#ifndef ACORN_CONTAINER_TUPLE_TUPLE_ELEMENT_H_
+#define ACORN_CONTAINER_TUPLE_TUPLE_ELEMENT_H_
 
 #include "acorn/traits/remove_const_ref.h"
 #include "acorn/traits/with_ref_matching.h"
@@ -42,27 +39,29 @@
 
 namespace acorn {
 
-#ifdef ACORN_STANDARD_LAYOUT_TUPLE
-#define INLINE_MEMBER inline
-#define INLINE_NESTED_INHERITED
-#else
-#define INLINE_MEMBER
-#define INLINE_NESTED_INHERITED inline
-#endif
+template <std::size_t I, template <typename...> class Tuple, typename... Args>
+struct TupleElementImpl;
 
-INLINE_MEMBER namespace member {
-template <typename... Args>
-using Tuple = MemberTuple<Args...>;
-}
+template <std::size_t I, template <typename...> class Tuple, typename First,
+          typename... Rest>
+struct TupleElementImpl<I, Tuple, First, Rest...>
+    : TupleElementImpl<I - 1, Tuple, Rest...> {};
 
-INLINE_NESTED_INHERITED namespace nested_inherited {
-template <typename... Args>
-using Tuple = NestedInheritedTuple<Args...>;
-}
+template <template <typename...> class Tuple, typename First, typename... Rest>
+struct TupleElementImpl<0, Tuple, First, Rest...> {
+  using type = First;
+  using TupleType = Tuple<First, Rest...>;
+};
 
-#undef INLINE_MEMBER
-#undef INLINE_NESTED_INHERITED
+template <std::size_t I, typename Tuple>
+struct TupleElement;
+
+template <std::size_t I, template <typename...> class Tuple, typename... Args>
+struct TupleElement<I, Tuple<Args...>> : TupleElementImpl<I, Tuple, Args...> {};
+
+template <std::size_t I, typename Tuple>
+using TupleElementType = typename TupleElement<I, Tuple>::type;
 
 }  // namespace acorn
 
-#endif  // ACORN_CONTAINER_TUPLE_H_
+#endif  // ACORN_CONTAINER_TUPLE_TUPLE_ELEMENT_H_

--- a/acorn/traits/BUILD
+++ b/acorn/traits/BUILD
@@ -1,8 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "macros",
-    srcs = ["macros.h"],
+    name = "traits",
+    hdrs = [
+        "remove_const_ref.h",
+        "with_ref_matching.h",
+    ],
     visibility = ["//visibility:public"],
-    deps = [],
 )

--- a/acorn/traits/remove_const_ref.h
+++ b/acorn/traits/remove_const_ref.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef ACORN_TRAITS_REMOVE_CONST_REF_H_
+#define ACORN_TRAITS_REMOVE_CONST_REF_H_
+
+#include <type_traits>
+
+namespace acorn {
+
+template <typename Type>
+struct RemoveConstRefImpl {
+  using type = typename std::remove_const<
+      typename std::remove_reference<Type>::type>::type;
+};
+
+template <typename Type>
+using RemoveConstRef = typename RemoveConstRefImpl<Type>::type;
+
+}  // namespace acorn
+
+#endif //  ACORN_TRAITS_REMOVE_CONST_REF_H_

--- a/acorn/traits/with_ref_matching.h
+++ b/acorn/traits/with_ref_matching.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef ACORN_TRAITS_WITH_REF_MATCHING_H_
+#define ACORN_TRAITS_WITH_REF_MATCHING_H_
+
+#include <type_traits>
+
+namespace acorn {
+
+template <typename Type, typename Target>
+struct WithRefMatchingImpl {
+  using type = Type;
+};
+
+template <typename Type, typename Target>
+struct WithRefMatchingImpl<Type, Target&> {
+  using type = typename std::add_lvalue_reference<Type>::type;
+};
+
+template <typename Type, typename Target>
+struct WithRefMatchingImpl<Type, Target const&> {
+  using type = typename std::add_lvalue_reference<
+      typename std::add_const<Type>::type>::type;
+};
+
+template <typename Type, typename Target>
+struct WithRefMatchingImpl<Type, Target&&> {
+  using type = typename std::add_rvalue_reference<Type>::type;
+};
+
+template <typename Type, typename Target>
+struct WithRefMatchingImpl<Type, Target const&&> {
+  using type = typename std::add_rvalue_reference<
+      typename std::add_const<Type>::type>::type;
+};
+
+template <typename Type, typename Target>
+using WithRefMatching = typename WithRefMatchingImpl<Type, Target>::type;
+
+}  // namespace acorn
+
+#endif  // ACORN_TRAITS_WITH_REF_MATCHING_H_

--- a/test/BUILD
+++ b/test/BUILD
@@ -49,7 +49,18 @@ cc_test(
 )
 
 cc_test(
-    name = "tuple",
+    name = "member_tuple",
+    size = "small",
+    srcs = ["tuple.cc"],
+    defines = ["ACORN_STANDARD_LAYOUT_TUPLE"],
+    deps = [
+        "//acorn/container:tuple",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "nested_inherited_tuple",
     size = "small",
     srcs = ["tuple.cc"],
     deps = [

--- a/test/BUILD
+++ b/test/BUILD
@@ -63,6 +63,17 @@ cc_test(
     name = "nested_inherited_tuple",
     size = "small",
     srcs = ["tuple.cc"],
+    defines = ["ACORN_NESTED_LAYOUT_TUPLE"],
+    deps = [
+        "//acorn/container:tuple",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "flat_inherited_tuple",
+    size = "small",
+    srcs = ["tuple.cc"],
     deps = [
         "//acorn/container:tuple",
         "@com_google_googletest//:gtest_main",

--- a/test/BUILD
+++ b/test/BUILD
@@ -47,3 +47,33 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "tuple",
+    size = "small",
+    srcs = ["tuple.cc"],
+    deps = [
+        "//acorn/container:tuple",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "with_ref_matching",
+    size = "small",
+    srcs = ["with_ref_matching.cc"],
+    deps = [
+        "//acorn/traits",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "remove_const_ref",
+    size = "small",
+    srcs = ["remove_const_ref.cc"],
+    deps = [
+        "//acorn/traits",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/test/remove_const_ref.cc
+++ b/test/remove_const_ref.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "acorn/traits/remove_const_ref.h"
+
+static_assert(std::is_same<int, acorn::RemoveConstRef<int>>::value,
+              "RemoveConstRef should not change non-const type");
+
+static_assert(std::is_same<int, acorn::RemoveConstRef<int &>>::value,
+              "RemoveConstRef should remove reference from reference type");
+
+static_assert(std::is_same<int, acorn::RemoveConstRef<int const &>>::value,
+              "RemoveConstRef should remove reference and const from const "
+              "reference type");
+
+static_assert(
+    std::is_same<int, acorn::RemoveConstRef<int &&>>::value,
+    "RemoveConstRef should remove reference from rvalue reference type");
+
+static_assert(std::is_same<int, acorn::RemoveConstRef<int const &&>>::value,
+              "RemoveConstRef should remove reference and const from const "
+              "rvalue reference type");

--- a/test/tuple.cc
+++ b/test/tuple.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "acorn/container/tuple.h"
+
+#include <gtest/gtest.h>
+
+namespace acorn {
+template<typename... Args>
+using Tuple = InheritedTuple<Args...>;
+//using Tuple = MemberTuple<Args...>;
+}  // namespace acorn
+
+static_assert(
+    std::is_same<acorn::TupleElement<0, acorn::Tuple<int>>::type, int>::value,
+    "First type of Tuple<int> should be int");
+
+static_assert(
+    std::is_same<acorn::TupleElement<0, acorn::Tuple<float, int>>::type,
+                 float>::value,
+    "First type of Tuple<float, int> should be float");
+
+static_assert(
+    std::is_same<acorn::TupleElement<1, acorn::Tuple<float, int>>::type,
+                 int>::value,
+    "Second type of Tuple<float, int> should be int");
+
+#if 0
+static_assert(std::is_standard_layout<acorn::Tuple<int>>::value,
+              "Tuple<int> should be standard layout");
+static_assert(std::is_standard_layout<acorn::Tuple<int, float>>::value,
+              "Tuple<int, float> should be standard layout");
+
+struct StructX {};
+static_assert(std::is_standard_layout<acorn::Tuple<StructX>>::value,
+              "Tuple<struct X> should be standard layout");
+static_assert(std::is_standard_layout<acorn::Tuple<StructX, int>>::value,
+              "Tuple<struct X, int> should be standard layout");
+#endif
+
+TEST(Tuple, ConstructEmptyTuple) {
+  acorn::Tuple<> a;
+  acorn::Tuple<> b{};
+
+  (void)a;
+  (void)b;
+}
+
+TEST(Tuple, ConstructFromSingleInts) {
+  acorn::Tuple<int> a(0);
+  acorn::Tuple<int> b{0};
+  acorn::Tuple<int> c = {0};
+  acorn::Tuple<int> d = acorn::Tuple<int>(0);
+  acorn::Tuple<int> e = acorn::Tuple<int>{0};
+
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  (void)e;
+}
+
+TEST(Tuple, AssignIntTuple) {
+  acorn::Tuple<int> a{1};
+  acorn::Tuple<int> const b = a;
+  acorn::Tuple<int> c = b;
+  acorn::Tuple<int> const d = std::move(a);
+
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+}
+
+TEST(Tuple, ExtractFromIntTuple) {
+  acorn::Tuple<int> a(0);
+
+  EXPECT_EQ(acorn::get<0>(a), 0);
+  acorn::get<0>(a) = 1;
+  EXPECT_EQ(acorn::get<0>(a), 1);
+}
+
+TEST(Tuple, ExtractFromConstIntTuple) {
+  acorn::Tuple<int, int> const a(0, 1);
+
+  EXPECT_EQ(acorn::get<0>(a), 0);
+  EXPECT_EQ(acorn::get<1>(a), 1);
+}
+
+TEST(Tuple, ConstructFromMultipleInts) {
+  acorn::Tuple<int, int> a(0, 1);
+  acorn::Tuple<int, int> b{0, 1};
+  acorn::Tuple<int, int> c = {0, 1};
+  acorn::Tuple<int, int> d = acorn::Tuple<int, int>(0, 1);
+  acorn::Tuple<int, int> e = acorn::Tuple<int, int>{0, 1};
+
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  (void)e;
+}
+
+struct NonCopiable {
+  NonCopiable() = default;
+  NonCopiable(int a) : val{a} {}
+  NonCopiable(NonCopiable const&) = delete;
+  NonCopiable(NonCopiable&&) = default;
+  int val = 0;
+};
+
+TEST(Tuple, ConstructFromNonCopiable) {
+  NonCopiable a{};
+  acorn::Tuple<NonCopiable> b{std::move(a)};
+
+  acorn::get<0>(b).val = 1;
+  EXPECT_EQ(acorn::get<0>(b).val, 1);
+}
+
+TEST(Tuple, MoveFromNonCopiable) {
+  NonCopiable a{1};
+  acorn::Tuple<NonCopiable> b{std::move(a)};
+  acorn::Tuple<NonCopiable> c{std::move(b)};
+  EXPECT_EQ(acorn::get<0>(c).val, 1);
+}
+
+TEST(Tuple, MoveFromMultipleNonCopiable) {
+  NonCopiable a{1};
+  NonCopiable b{2};
+  acorn::Tuple<NonCopiable, NonCopiable, int> c{std::move(a), std::move(b), 3};
+  acorn::Tuple<NonCopiable, NonCopiable, int> d{std::move(c)};
+  EXPECT_EQ(acorn::get<0>(d).val, 1);
+  EXPECT_EQ(acorn::get<1>(d).val, 2);
+  EXPECT_EQ(acorn::get<2>(d), 3);
+}

--- a/test/tuple.cc
+++ b/test/tuple.cc
@@ -32,12 +32,6 @@
 
 #include <gtest/gtest.h>
 
-namespace acorn {
-template<typename... Args>
-using Tuple = InheritedTuple<Args...>;
-//using Tuple = MemberTuple<Args...>;
-}  // namespace acorn
-
 static_assert(
     std::is_same<acorn::TupleElement<0, acorn::Tuple<int>>::type, int>::value,
     "First type of Tuple<int> should be int");
@@ -52,7 +46,7 @@ static_assert(
                  int>::value,
     "Second type of Tuple<float, int> should be int");
 
-#if 0
+#ifdef ACORN_STANDARD_LAYOUT_TUPLE
 static_assert(std::is_standard_layout<acorn::Tuple<int>>::value,
               "Tuple<int> should be standard layout");
 static_assert(std::is_standard_layout<acorn::Tuple<int, float>>::value,

--- a/test/with_ref_matching.cc
+++ b/test/with_ref_matching.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, John Lawson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "acorn/traits/with_ref_matching.h"
+
+static_assert(std::is_same<int, acorn::WithRefMatching<int, float>>::value,
+              "WithRefMatching should not add anything for types");
+
+static_assert(std::is_same<int&, acorn::WithRefMatching<int, float&>>::value,
+              "WithRefMatching should add reference to match reference type");
+
+static_assert(
+    std::is_same<int const&, acorn::WithRefMatching<int, float const&>>::value,
+    "WithRefMatching should add const reference to match reference type");
+
+static_assert(
+    std::is_same<int&&, acorn::WithRefMatching<int, float&&>>::value,
+    "WithRefMatching should add rvalue reference to match reference type");
+
+static_assert(std::is_same<int const&&,
+                           acorn::WithRefMatching<int, float const&&>>::value,
+              "WithRefMatching should add const rvalue reference to match "
+              "reference type");


### PR DESCRIPTION
Provide fairly minimal implementations of Tuple, using two different
techniques. The inheritance based method allows easier access to
elements and potentially packs elements better, while the member based
implementation will be standard layout and so could be used where that
is required.